### PR TITLE
resolve issues with update_h2eff_sub()

### DIFF
--- a/gpu/src/device.cpp
+++ b/gpu/src/device.cpp
@@ -194,6 +194,7 @@ Device::~Device()
     pm->dev_free(dd->d_dms);
     pm->dev_free(dd->d_dmtril);
     pm->dev_free(dd->d_eri1);
+    pm->dev_free(dd->d_h2eff);
     pm->dev_free(dd->d_mo_coeff);
     
     for(int i=0; i<dd->size_pumap.size(); ++i) {

--- a/gpu/src/device.h
+++ b/gpu/src/device.h
@@ -207,6 +207,7 @@ private:
     std::vector<int *> pumap;
     std::vector<int *> d_pumap;
     int * d_pumap_ptr; // no explicit allocation
+    int * pumap_ptr; // no explicit allocation
 
 #if defined (_USE_GPU)
     cublasHandle_t handle;


### PR DESCRIPTION
Not sure why/how, but majority of the key differences appear to be with the packing and unpacking functions. I left the mappings in dd_fetch_pumap() as selectable for when we focus on tuning performance of the kernels. 

This gives correct answers for {1, 2, 4, 8, 16}-mers of polymer_async.