### PR TITLE
Cleaned up df_ao2mo_pass1_fdrv

### DIFF
--- a/gpu/gpu4pyscf/mcscf/df.py
+++ b/gpu/gpu4pyscf/mcscf/df.py
@@ -342,7 +342,7 @@ class _ERIS:
         t1 = t0 = (logger.process_clock(), logger.perf_counter())
         gpu=casscf.mol.use_gpu#print(bufpp)
         if gpu: 
-            libgpu.libgpu_transfer_mo_coeff(gpu, mo, nao*nmo)
+            libgpu.libgpu_push_mo_coeff(gpu, mo, nao*nmo)
         count = 0
         for k, eri1 in enumerate(with_df.loop(blksize)):
             naux = eri1.shape[0]

--- a/gpu/gpu4pyscf/mcscf/df.py
+++ b/gpu/gpu4pyscf/mcscf/df.py
@@ -329,7 +329,9 @@ class _ERIS:
         mo = numpy.asarray(mo, order='F')
         fxpp = lib.H5TmpFile()
 
-        blksize = max(4, int(min(with_df.blockdim, (max_memory*.95e6/8-naoaux*nmo*ncas)/3/nmo**2)))
+#        blksize = max(4, int(min(with_df.blockdim, (max_memory*.95e6/8-naoaux*nmo*ncas)/3/nmo**2)))
+        blksize = with_df.blockdim
+
         bufpa = numpy.empty((naoaux,nmo,ncas))
         bufs1 = numpy.empty((blksize,nmo,nmo))
         fmmm = _ao2mo.libao2mo.AO2MOmmm_nr_s2_iltj
@@ -341,13 +343,13 @@ class _ERIS:
         gpu=casscf.mol.use_gpu#print(bufpp)
         if gpu: 
             libgpu.libgpu_transfer_mo_coeff(gpu, mo, nao*nmo)
+        count = 0
         for k, eri1 in enumerate(with_df.loop(blksize)):
             naux = eri1.shape[0]
             bufpp = bufs1[:naux]
             if DEBUG and gpu:
                 bufpp2 = numpy.empty((naux,nmo,nmo))#bufs1[:naux]
-
-                libgpu.libgpu_df_ao2mo_pass1_fdrv(gpu,naux,nmo,nao,blksize,bufpp,mo,eri1)
+                libgpu.libgpu_df_ao2mo_pass1_fdrv(gpu,naux,nmo,nao,blksize,bufpp,mo,eri1,count,id(with_df))
                 fdrv(ftrans, fmmm,
                  bufpp2.ctypes.data_as(ctypes.c_void_p),
                  eri1.ctypes.data_as(ctypes.c_void_p),
@@ -364,7 +366,7 @@ class _ERIS:
 
             else:
                 if gpu:
-                    libgpu.libgpu_df_ao2mo_pass1_fdrv(gpu,naux,nmo,nao,blksize,bufpp,mo, eri1)
+                    libgpu.libgpu_df_ao2mo_pass1_fdrv(gpu,naux,nmo,nao,blksize,bufpp,mo, eri1,count,id(with_df))
                     t0 = log.timer('density fitting ao2mo pass1_loop gpu', *t0)
                 else:
                     fdrv(ftrans, fmmm,
@@ -386,6 +388,8 @@ class _ERIS:
             b0 += naux
             t0 = log.timer('rest of the calculation', *t0)
             #t1 = log.timer_debug1('j_pc and k_pc', *t1)
+            count += 1
+            
         self.k_pc = k_cp.T.copy()
         bufs1 = bufpp = None
         t1 = log.timer('density fitting ao2mo pass1', *t1)

--- a/gpu/src/device.h
+++ b/gpu/src/device.h
@@ -77,8 +77,9 @@ public :
   void get_dfobj_status(size_t, py::array_t<int>);
  
   void df_ao2mo_pass1_fdrv (int, int, int, int,
-		       py::array_t<double>, py::array_t<double>,
-		       py::array_t<double>);
+			    py::array_t<double>, py::array_t<double>,
+			    py::array_t<double>,
+			    int, size_t);
   
   void orbital_response(py::array_t<double>,
 			py::array_t<double>, py::array_t<double>, py::array_t<double>,

--- a/gpu/src/device.h
+++ b/gpu/src/device.h
@@ -95,7 +95,7 @@ public :
                     int , int , int , int , int ,
                     py::array_t<double> );
 
-  void transfer_mo_coeff(py::array_t<double>, int);
+  void push_mo_coeff(py::array_t<double>, int);
 private:
 
   class PM * pm;
@@ -221,8 +221,6 @@ private:
   int * dd_fetch_pumap(my_device_data *, int, int);
   double * dd_fetch_eri(my_device_data *, double *, size_t, int);
   double * dd_fetch_eri_debug(my_device_data *, double *, size_t, int); // we'll trash this after some time
-  
-  void push_mo_coeff(my_device_data *, double *, int);
   
   void fdrv(double *, double *, double *,
 	    int, int, int *, int *, int, double *);

--- a/gpu/src/device_cuda.cpp
+++ b/gpu/src/device_cuda.cpp
@@ -1064,7 +1064,7 @@ void Device::df_ao2mo_pass1_fdrv (int naux, int nmo, int nao, int blksize,
 				  py::array_t<double> _bufpp, py::array_t<double> _mo_coeff, py::array_t<double> _eri1,
 				  int count, size_t addr_dfobj)
 {
-  const int device_id = 0;//count % num_devices;
+  const int device_id = count % num_devices;
   
   pm->dev_set_device(device_id);
   
@@ -1093,24 +1093,12 @@ void Device::df_ao2mo_pass1_fdrv (int naux, int nmo, int nao, int blksize,
 #endif
   
   const int nao_pair = nao*(nao+1)/2;
-  
 
   double * eri = static_cast<double*>(info_eri1.ptr);
+  double * bufpp = static_cast<double*>(info_bufpp.ptr);
+  
   int _size_eri = naux * nao_pair;
   int _size_eri_unpacked = naux * nao * nao; 
-
-  double * bufpp = static_cast<double*>(info_bufpp.ptr);
-  //int _size_bufpp = naux * nao * nao;
-
-#if 1
-  double * d_mo_coeff = dd->d_mo_coeff;
-#else
-  py::buffer_info info_mo_coeff = _mo_coeff.request(); // 2D array (nmo, nmo)
-  double *d_mo_coeff= (double*) pm->dev_malloc(_size_mo_coeff*sizeof(double));//allocate mo_coeff (might be able to avoid if already used in get_jk)
-  pm->dev_push(d_mo_coeff, mo_coeff, _size_mo_coeff * sizeof(double));//doing this allocation and pushing first because it doesn't change over iteration 
-  double * mo_coeff = static_cast<double*>(info_mo_coeff.ptr);
-  int _size_mo_coeff = nao * nao;
-#endif
   
 #ifdef _DEBUG_DEVICE
   size_t freeMem;size_t totalMem;
@@ -1118,85 +1106,92 @@ void Device::df_ao2mo_pass1_fdrv (int naux, int nmo, int nao, int blksize,
   cudaMemGetInfo(&freeMem, &totalMem);
   printf("Starting ao2mo fdrv Free memory %lu bytes, total memory %lu bytes\n",freeMem,totalMem);
 #endif
-  {
-  double * d_buf_1 = (double*) pm->dev_malloc(_size_eri_unpacked*sizeof(double));//new
-  double * d_buf_2 = (double*) pm->dev_malloc(_size_eri_unpacked*sizeof(double));//new
-  double * d_buf = d_buf_1; //for eri*mo_coeff (don't pull or push) 
-  double * d_eri_unpacked = d_buf_2;//set memory for the entire eri array on GPU
+
+  if(_size_eri_unpacked > dd->size_buf) {
+    dd->size_buf = _size_eri_unpacked;
+    
+    if(dd->d_buf1) pm->dev_free_async(dd->d_buf1, dd->stream);
+    if(dd->d_buf2) pm->dev_free_async(dd->d_buf2, dd->stream);
+    
+    dd->d_buf1 = (double *) pm->dev_malloc_async(dd->size_buf * sizeof(double), dd->stream);
+    dd->d_buf2 = (double *) pm->dev_malloc_async(dd->size_buf * sizeof(double), dd->stream);
+  }
+  
+  double * d_buf = dd->d_buf1; //for eri*mo_coeff (don't pull or push) 
+  double * d_eri_unpacked = dd->d_buf2; //set memory for the entire eri array on GPU
   
   //unpack 2D eri of size naux * nao(nao+1)/2 to a full naux*nao*nao 3D matrix
   
   double * d_eri;
-
-#if 1
-  if(use_eri_cache)
-    d_eri = dd_fetch_eri(dd, eri, addr_dfobj, count);
-#else
-  d_eri = (double*) pm->dev_malloc (sizeof(double)* _size_eri);//set memory for the entire eri array on GPU
-  pm->dev_push(d_eri, eri, _size_eri * sizeof(double));//doing this allocation and pushing first because it doesn't change over iterations.
-#endif
   
-  int _size_tril_map = nao * nao;
-  int * my_tril_map = (int*) malloc (_size_tril_map * sizeof(int));
-  int * my_d_tril_map = (int*) pm->dev_malloc (_size_tril_map * sizeof(int));
-    int _i, _j, _ij;
-    for(_ij = 0, _i = 0; _i < nao; ++_i)
-      for(_j = 0; _j<=_i; ++_j, ++_ij) {
-    	my_tril_map[_i*nao + _j] = _ij;
-    	my_tril_map[_i + nao*_j] = _ij;
-    } 
-  int * my_d_tril_map_ptr=my_d_tril_map;
-  pm->dev_push(my_d_tril_map,my_tril_map,_size_tril_map*sizeof(int));
-  dim3 grid_size(_TILE(naux,_UNPACK_BLOCK_SIZE), _TILE(nao*nao, _UNPACK_BLOCK_SIZE), 1);
-  dim3 block_size(_UNPACK_BLOCK_SIZE, _UNPACK_BLOCK_SIZE, 1);
-  _getjk_unpack_buf2<<<grid_size,block_size,0,dd->stream>>>(d_eri_unpacked, d_eri, my_d_tril_map_ptr, naux, nao, nao_pair);
+  if(use_eri_cache) {
+    d_eri = dd_fetch_eri(dd, eri, addr_dfobj, count);
+  } else {
+    if(_size_eri > dd->size_eri1) {
+      dd->size_eri1 = _size_eri;
+      if(dd->d_eri1) pm->dev_free_async(dd->d_eri1, dd->stream);
+      dd->d_eri1 = (double *) pm->dev_malloc_async(_size_eri * sizeof(double), dd->stream);
+    }
+    
+    pm->dev_push(d_eri, eri, _size_eri * sizeof(double));
+  }
+  
+  int * my_d_tril_map_ptr = dd_fetch_pumap(dd, nao);
+  
+  {
+    dim3 grid_size(_TILE(naux,_UNPACK_BLOCK_SIZE), _TILE(nao*nao, _UNPACK_BLOCK_SIZE), 1);
+    dim3 block_size(_UNPACK_BLOCK_SIZE, _UNPACK_BLOCK_SIZE, 1);
+    _getjk_unpack_buf2<<<grid_size,block_size,0,dd->stream>>>(d_eri_unpacked, d_eri, my_d_tril_map_ptr, naux, nao, nao_pair);
+  }
+  
 #ifdef _DEBUG_DEVICE
   printf("Finished unpacking\n");
-#endif
-  double alpha = 1.0;
-  double beta = 0.0;
-  //bufpp = mo.T @ eri @ mo 
-#ifdef _DEBUG_DEVICE
   printf("LIBGPU ::  -- calling cublasDgemmStrideBatched() in ao2mo_fdrv\n");
 #endif
-  profile_stop ();
-  profile_start(" df_ao2mo_pass1_fdrv StridedBatchedDgemm\n");
-  //buf = np.einsum('ijk,kl->ijl',eri_unpacked,mo_coeff),i=naux,j=nao,l=nao 
+  
+  //bufpp = mo.T @ eri @ mo
+  
+  profile_next(" df_ao2mo_pass1_fdrv StridedBatchedDgemm\n");
+  
+  //buf = np.einsum('ijk,kl->ijl',eri_unpacked,mo_coeff),i=naux,j=nao,l=nao
+  
+  double alpha = 1.0;
+  double beta = 0.0;
   cublasDgemmStridedBatched(dd->handle, 
-                      CUBLAS_OP_N, CUBLAS_OP_N,nao, nao, nao, 
-                      &alpha,d_eri_unpacked, nao, nao*nao,d_mo_coeff, nao, 0, 
-                      &beta,d_buf, nao, nao*nao,naux);
+			    CUBLAS_OP_N, CUBLAS_OP_N,nao, nao, nao, 
+			    &alpha,d_eri_unpacked, nao, nao*nao, dd->d_mo_coeff, nao, 0, 
+			    &beta,d_buf, nao, nao*nao,naux);
   _CUDA_CHECK_ERRORS();
-  //pm->dev_free(d_eri_unpacked);
+  
 #ifdef _DEBUG_DEVICE
   printf("LIBGPU ::  -- calling cublasDgemmStrideBatched() in ao2mo_fdrv \n");
 #endif
-  //bufpp = np.einsum('jk,ikl->ijl',mo_coeff.T,buf),i=naux,j=nao,l=nao 
-  //double * d_bufpp = (double*) pm->dev_malloc (sizeof(double)* _size_bufpp);//set memory for the entire bufpp array, no pushing needed 
-  double * d_bufpp = d_buf_2;//set memory for the entire bufpp array, no pushing needed 
+  
+  //bufpp = np.einsum('jk,ikl->ijl',mo_coeff.T,buf),i=naux,j=nao,l=nao
+  
+  double * d_bufpp = dd->d_buf2;//set memory for the entire bufpp array, no pushing needed 
   cublasDgemmStridedBatched(dd->handle, CUBLAS_OP_T, CUBLAS_OP_N, nao, nao, nao, 
-                      &alpha,d_mo_coeff, nao, 0, d_buf, nao, nao*nao, 
-                      &beta, d_bufpp, nao, nao*nao,naux);
+			    &alpha, dd->d_mo_coeff, nao, 0, d_buf, nao, nao*nao, 
+			    &beta, d_bufpp, nao, nao*nao,naux);
   _CUDA_CHECK_ERRORS();
+
+  profile_next(" df_ao2mo_pass1_fdrv Data pull\n");
+  
+  pm->dev_pull_async(d_bufpp, bufpp, _size_eri_unpacked * sizeof(double), dd->stream);
+
+  pm->dev_stream_wait(dd->stream);
+  
   profile_stop();
-  profile_start(" df_ao2mo_pass1_fdrv Data pull\n");
-  pm->dev_pull(d_bufpp, bufpp, _size_eri_unpacked * sizeof(double));
-  pm->dev_free(my_d_tril_map);
-#if 0
-  pm->dev_free(d_eri);
-#endif
-  pm->dev_free(d_buf_1);
-  pm->dev_free(d_buf_2);
-  profile_stop();
+  
 #ifdef _DEBUG_DEVICE
-    printf("LIBGPU :: Leaving Device::df_ao2mo_pass1_fdrv()\n"); 
-    cudaMemGetInfo(&freeMem, &totalMem);
-    printf("Ending ao2mo fdrv Free memory %lu bytes, total memory %lu bytes\n",freeMem,totalMem);
+  printf("LIBGPU :: Leaving Device::df_ao2mo_pass1_fdrv()\n"); 
+  cudaMemGetInfo(&freeMem, &totalMem);
+  printf("Ending ao2mo fdrv Free memory %lu bytes, total memory %lu bytes\n",freeMem,totalMem);
 #endif
-  }
+  
 #ifdef _SIMPLE_TIMER
-    double t1 = omp_get_wtime();
-    t_array[5] += t1 - t0;
+  double t1 = omp_get_wtime();
+  t_array[5] += t1 - t0;
 #endif
 }
 

--- a/gpu/src/libgpu.cpp
+++ b/gpu/src/libgpu.cpp
@@ -129,11 +129,11 @@ void libgpu_get_dfobj_status(void * ptr, size_t addr_dfobj, py::array_t<int> arg
 
 /* ---------------------------------------------------------------------- */
 
-void libgpu_transfer_mo_coeff(void * ptr,
-                              py::array_t<double> mo_coeff, int size_mo_coeff)
+void libgpu_push_mo_coeff(void * ptr,
+			  py::array_t<double> mo_coeff, int size_mo_coeff)
 {
   Device * dev = (Device *) ptr;
-  dev->transfer_mo_coeff(mo_coeff, size_mo_coeff);
+  dev->push_mo_coeff(mo_coeff, size_mo_coeff);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/gpu/src/libgpu.cpp
+++ b/gpu/src/libgpu.cpp
@@ -139,12 +139,13 @@ void libgpu_transfer_mo_coeff(void * ptr,
 /* ---------------------------------------------------------------------- */
 
 void libgpu_df_ao2mo_pass1_fdrv(void * ptr,
-			    int naux, int nmo, int nao, int blksize,
-			py::array_t<double> bufpp, py::array_t<double> mo,
-			py::array_t<double> eri1)
+				int naux, int nmo, int nao, int blksize,
+				py::array_t<double> bufpp, py::array_t<double> mo,
+				py::array_t<double> eri1,
+				int count, size_t addr_dfobj)
 { 
   Device * dev = (Device *) ptr;
-  dev->df_ao2mo_pass1_fdrv(naux, nmo, nao, blksize, bufpp, mo, eri1);
+  dev->df_ao2mo_pass1_fdrv(naux, nmo, nao, blksize, bufpp, mo, eri1, count, addr_dfobj);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/gpu/src/libgpu.h
+++ b/gpu/src/libgpu.h
@@ -58,6 +58,10 @@ extern "C"
                            py::array_t<double> ,  
                            int , int , int , int , int ,
                            py::array_t<double> ,py::array_t<double> );
+  void libgpu_get_h2eff_df(void * , 
+                           py::array_t<double> , 
+                           int , int , int , int , int ,
+                           py::array_t<double> );
 }
 
 
@@ -84,6 +88,7 @@ PYBIND11_MODULE(libgpu, m) {
   m.def("libgpu_df_ao2mo_pass1_fdrv", &libgpu_df_ao2mo_pass1_fdrv, "pyscf/mcscf/df.py::_ERIS.__init__() part 1");
   m.def("libgpu_update_h2eff_sub", &libgpu_update_h2eff_sub, "my_pyscf/mcscf/lasci_sync.py::_update_h2_eff()");
   m.def("libgpu_h2eff_df_contract1", &libgpu_h2eff_df_contract1, "my_pyscf/df/sparse_df.py::contract1");
+  m.def("libgpu_get_h2eff_df", &libgpu_get_h2eff_df, "my_pyscf/mcscf/las_ao2mo.py::get_h2eff_df");
   
   m.def("libgpu_orbital_response", &libgpu_orbital_response, "mrh/lasscf_sync_o0.py::orbital_response");
 }

--- a/gpu/src/libgpu.h
+++ b/gpu/src/libgpu.h
@@ -37,8 +37,8 @@ extern "C"
   void libgpu_get_dfobj_status(void *, size_t, py::array_t<int>);
   
 
-  void libgpu_transfer_mo_coeff(void *, 
-                                py::array_t<double>, int);
+  void libgpu_push_mo_coeff(void *, 
+			    py::array_t<double>, int);
   
   void libgpu_df_ao2mo_pass1_fdrv (void *,
 			      int, int, int, int,
@@ -84,7 +84,7 @@ PYBIND11_MODULE(libgpu, m) {
   m.def("libgpu_set_update_dfobj_", &libgpu_set_update_dfobj_, "ensure that eri is updated on device for get_jk");
   m.def("libgpu_get_dfobj_status", &libgpu_get_dfobj_status, "retrieve info on dfobj and cached eri blocks on device");
 
-  m.def("libgpu_transfer_mo_coeff", &libgpu_transfer_mo_coeff, "pyscf/mcscf/df.py::_ERIS.__init__() part 0");
+  m.def("libgpu_push_mo_coeff", &libgpu_push_mo_coeff, "pyscf/mcscf/df.py::_ERIS.__init__() part 0");
   m.def("libgpu_df_ao2mo_pass1_fdrv", &libgpu_df_ao2mo_pass1_fdrv, "pyscf/mcscf/df.py::_ERIS.__init__() part 1");
   m.def("libgpu_update_h2eff_sub", &libgpu_update_h2eff_sub, "my_pyscf/mcscf/lasci_sync.py::_update_h2_eff()");
   m.def("libgpu_h2eff_df_contract1", &libgpu_h2eff_df_contract1, "my_pyscf/df/sparse_df.py::contract1");

--- a/gpu/src/libgpu.h
+++ b/gpu/src/libgpu.h
@@ -43,7 +43,8 @@ extern "C"
   void libgpu_df_ao2mo_pass1_fdrv (void *,
 			      int, int, int, int,
 			      py::array_t<double>, py::array_t<double>,
-			      py::array_t<double>); 
+				   py::array_t<double>,
+				   int, size_t); 
   
   void libgpu_orbital_response(void *,
 			       py::array_t<double>,
@@ -57,11 +58,6 @@ extern "C"
                            py::array_t<double> ,  
                            int , int , int , int , int ,
                            py::array_t<double> ,py::array_t<double> );
-  void libgpu_get_h2eff_df(void * , 
-                           py::array_t<double> , 
-                           int , int , int , int , int ,
-                           py::array_t<double> );
-
 }
 
 
@@ -88,8 +84,6 @@ PYBIND11_MODULE(libgpu, m) {
   m.def("libgpu_df_ao2mo_pass1_fdrv", &libgpu_df_ao2mo_pass1_fdrv, "pyscf/mcscf/df.py::_ERIS.__init__() part 1");
   m.def("libgpu_update_h2eff_sub", &libgpu_update_h2eff_sub, "my_pyscf/mcscf/lasci_sync.py::_update_h2_eff()");
   m.def("libgpu_h2eff_df_contract1", &libgpu_h2eff_df_contract1, "my_pyscf/df/sparse_df.py::contract1");
-
-  m.def("libgpu_get_h2eff_df", &libgpu_get_h2eff_df, "my_pyscf/mcscf/las_ao2mo.py::get_h2eff_df");
   
   m.def("libgpu_orbital_response", &libgpu_orbital_response, "mrh/lasscf_sync_o0.py::orbital_response");
 }

--- a/my_pyscf/mcscf/las_ao2mo.py
+++ b/my_pyscf/mcscf/las_ao2mo.py
@@ -13,7 +13,7 @@ def get_h2eff_df (las, mo_coeff):
     nocc = ncore + ncas
     mo_cas = mo_coeff[:,ncore:nocc]
     if gpu: 
-        libgpu.libgpu_transfer_mo_coeff(gpu,mo_cas.copy(),mo_cas.size)#TODO: make it async 
+        libgpu.libgpu_push_mo_coeff(gpu,mo_cas.copy(),mo_cas.size)
     naux = las.with_df.get_naoaux ()
     log.debug2 ("LAS DF ERIs: %d MB used of %d MB total available", lib.current_memory ()[0], las.max_memory)
     mem_eris = 8*(nao+nmo)*ncas*ncas*ncas / 1e6
@@ -95,7 +95,7 @@ def get_h2eff_gpu (las,mo_coeff):
     ncore, ncas = las.ncore, las.ncas
     nocc = ncore + ncas
     mo_cas = mo_coeff[:,ncore:nocc]
-    if gpu: libgpu.libgpu_transfer_mo_coeff(gpu,mo_coeff.copy(),mo_coeff.size)#TODO: make it async 
+    if gpu: libgpu.libgpu_push_mo_coeff(gpu,mo_coeff.copy(),mo_coeff.size)
     naux = las.with_df.get_naoaux ()
     if gpu: blksize = 50
     else:


### PR DESCRIPTION
* Cleaned up memory management using device_data buffers
* Used helper functions for eri and pumap
* Renamed libgpu_transfer_mo_coeff() as libgpu_push_mo_coeff() to clarify direction of data transfer
* Multi-gpu support enabled for df_ao2mo_pass1_fdrv(), but effectively serialized because of bufpp array usage
* The new Device::push_mo_coeff() now supports multiple GPUs; will later add new bcast()-type function to leverage GPU-GPU connections.

