### PR TITLE
helper functions for multi-gpu communication

### DIFF
--- a/gpu/src/device.h
+++ b/gpu/src/device.h
@@ -33,6 +33,7 @@ using namespace MATHLIB_NS;
 //#define _DEBUG_H2EFF_DF
 //#define _DEBUG_AO2MO
 //#define _DEBUG_PACKING
+//#define _DEBUG_P2P
 
 #define _PUMAP_2D_UNPACK 0       // generic unpacking of 1D array to 2D matrix
 #define _PUMAP_H2EFF_UNPACK 1    // unpacking h2eff array (generic?)
@@ -179,7 +180,7 @@ public :
   // multi-gpu communication (better here or part of PM?)
 
   void mgpu_bcast(std::vector<double *>, double *, size_t);
-  //  void mgpu_reduce();
+  void mgpu_reduce(std::vector<double *>, double *, int, bool, std::vector<double *>);
   
 private:
 

--- a/gpu/src/device.h
+++ b/gpu/src/device.h
@@ -174,7 +174,13 @@ public :
   
   void push_mo_coeff(py::array_t<double>, int);
 
-  void vecadd(const double *, double *, int);
+  void vecadd(const double *, double *, int); // replace with ml->daxpy()
+
+  // multi-gpu communication (better here or part of PM?)
+
+  void mgpu_bcast(std::vector<double *>, double *, size_t);
+  //  void mgpu_reduce();
+  
 private:
 
   class PM * pm;


### PR DESCRIPTION
* added `mgpu_bcast()` to broadcast data from host to all GPUs
* added `mgpu_reduce()` to reduce array of values from all GPUs and send to host
* Peer-to-peer support can be disabled by commenting out `#define _ENABLE_P2P` in device.h in event of error or compute node does not support P2P