### PR TITLE
param.use_gpu default fix and Midway3 architecture fix

### DIFF
--- a/gpu/gpu4mrh/fci/rdm.py
+++ b/gpu/gpu4mrh/fci/rdm.py
@@ -15,7 +15,7 @@ def _make_rdm1_spin1(fname, cibra, ciket, norb, nelec, link_index=None):
       gpu = param.use_gpu
     except: 
       use_gpu = None
-    if (fname in ['FCItrans_rdm1a', 'FCItrans_rdm1b', 'FCImake_rdm1a', 'FCImake_rdm1b']) and param.use_gpu is not None:
+    if (fname in ['FCItrans_rdm1a', 'FCItrans_rdm1b', 'FCImake_rdm1a', 'FCImake_rdm1b']) and (use_gpu is not None):
         use_gpu = param.use_gpu
         gpu = param.use_gpu
     else:
@@ -125,7 +125,7 @@ def _make_rdm12_spin1(fname, cibra, ciket, norb, nelec, link_index=None, symm=0)
     #add traceback
     #    traceback.print_stack(file=sys.stdout)
     from pyscf.lib import param
-    if (fname in ['FCItdm12kern_a', 'FCItdm12kern_b', 'FCItdm12kern_ab', 'FCIrdm12kern_sf']) and param.use_gpu is not None:
+    if (fname in ['FCItdm12kern_a', 'FCItdm12kern_b', 'FCItdm12kern_ab', 'FCIrdm12kern_sf']) and getattr (param, 'use_gpu', None) is not None:
        use_gpu = param.use_gpu
        gpu=param.use_gpu
     else: 

--- a/gpu/src/arch/midway3
+++ b/gpu/src/arch/midway3
@@ -15,7 +15,7 @@ CXXFLAGS += -D_USE_NVTX
 
 CUDA_CXX = nvcc
 CUDA_CXXFLAGS = -x cu $(PYTHON_INC)
-CUDA_CXXFLAGS += -arch=sm_37
+CUDA_CXXFLAGS += -arch=sm_70
 CUDA_CXXFLAGS += -Xcompiler -fopenmp
 #CUDA_CXXFLAGS += -shared -Xcompiler -fPIC 
 CUDA_CXXFLAGS += -D_USE_GPU -D_GPU_CUDA -D_GPU_CUBLAS


### PR DESCRIPTION
`getattr (object, 'attribute', default)` is a powerful tool in situations like this.

Everything in `tests/gpu` passes with this, although there are some printout lines that should be cleaned up.